### PR TITLE
improve(networks): Support tagging chain families

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -36,38 +36,142 @@ export const CHAIN_IDs = {
   ...TESTNET_CHAIN_IDs,
 };
 
+enum ChainFamily {
+  OP_STACK,
+};
+
 interface PublicNetwork {
   name: string;
   nativeToken: string;
   blockExplorer: string;
+  family?: ChainFamily;
 }
 
+const { OP_STACK } = ChainFamily;
 export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
-  [CHAIN_IDs.ARBITRUM]: { name: "Arbitrum One", nativeToken: "ETH", blockExplorer: "https://arbiscan.io" },
-  [CHAIN_IDs.BASE]: { name: "Base", nativeToken: "ETH", blockExplorer: "https://basescan.org" },
-  [CHAIN_IDs.BLAST]: { name: "Blast", nativeToken: "ETH", blockExplorer: "https://blastscan.io" },
-  [CHAIN_IDs.BOBA]: { name: "Boba", nativeToken: "ETH", blockExplorer: "https://blockexplorer.boba.network" },
-  [CHAIN_IDs.LINEA]: { name: "Linea", nativeToken: "ETH", blockExplorer: "https://lineascan.build" },
-  [CHAIN_IDs.LISK]: { name: "Lisk", nativeToken: "ETH", blockExplorer: "https://blockscout.lisk.com" },
-  [CHAIN_IDs.MAINNET]: { name: "Mainnet",  nativeToken: "ETH", blockExplorer: "https://etherscan.io" },
-  [CHAIN_IDs.MODE]: { name: "Mode", nativeToken: "ETH", blockExplorer: "https://explorer.mode.network" },
-  [CHAIN_IDs.OPTIMISM]: { name: "Optimism", nativeToken: "ETH", blockExplorer: "https://optimistic.etherscan.io" },
-  [CHAIN_IDs.POLYGON]: { name: "Polygon",  nativeToken: "MATIC", blockExplorer: "https://polygonscan.com" },
-  [CHAIN_IDs.SCROLL]: { name: "Scroll", nativeToken: "ETH", blockExplorer: "https://scrollscan.com" },
-  [CHAIN_IDs.ZK_SYNC]: { name: "zkSync", nativeToken: "ETH", blockExplorer: "https://era.zksync.network" }
+  [CHAIN_IDs.ARBITRUM]: {
+    name: "Arbitrum One",
+    nativeToken: "ETH",
+    blockExplorer: "https://arbiscan.io"
+  },
+  [CHAIN_IDs.BASE]: {
+    name: "Base",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://basescan.org"
+  },
+  [CHAIN_IDs.BLAST]: {
+    name: "Blast",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://blastscan.io"
+  },
+  [CHAIN_IDs.BOBA]: {
+    name: "Boba",
+    nativeToken: "ETH",
+    blockExplorer: "https://blockexplorer.boba.network"
+  },
+  [CHAIN_IDs.LINEA]: {
+    name: "Linea",
+    nativeToken: "ETH",
+    blockExplorer: "https://lineascan.build"
+  },
+  [CHAIN_IDs.LISK]: {
+    name: "Lisk",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://blockscout.lisk.com"
+  },
+  [CHAIN_IDs.MAINNET]: {
+    name: "Mainnet",
+    nativeToken: "ETH",
+    blockExplorer: "https://etherscan.io"
+  },
+  [CHAIN_IDs.MODE]: {
+    name: "Mode",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://explorer.mode.network"
+  },
+  [CHAIN_IDs.OPTIMISM]: {
+    name: "Optimism",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://optimistic.etherscan.io"
+  },
+  [CHAIN_IDs.POLYGON]: {
+    name: "Polygon",
+    nativeToken: "MATIC",
+    blockExplorer: "https://polygonscan.com"
+  },
+  [CHAIN_IDs.SCROLL]: {
+    name: "Scroll",
+    nativeToken: "ETH",
+    blockExplorer: "https://scrollscan.com"
+  },
+  [CHAIN_IDs.ZK_SYNC]: {
+    name: "zkSync",
+    nativeToken: "ETH",
+    blockExplorer: "https://era.zksync.network"
+  }
 };
 
 export const TEST_NETWORKS: { [chainId: number]: PublicNetwork } = {
-  [CHAIN_IDs.ARBITRUM_SEPOLIA]: { name: "Arbitrum Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.arbiscan.io" },
-  [CHAIN_IDs.BASE_SEPOLIA]: { name: "Base Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.basescan.org" },
-  [CHAIN_IDs.BLAST_SEPOLIA]: { name: "Blast Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.blastscan.io" },
-  [CHAIN_IDs.LISK_SEPOLIA]: { name: "Lisk Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia-blockscout.lisk.com" },
-  [CHAIN_IDs.MODE_SEPOLIA]: { name: "Mode Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.explorer.mode.network" },
-  [CHAIN_IDs.OPTIMISM_SEPOLIA]: { name: "Optimism Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia-optimism.etherscan.io" },
-  [CHAIN_IDs.POLYGON_AMOY]: { name: "Polygon Amoy", nativeToken: "MATIC", blockExplorer: "https://amoy.polygonscan.com" },
-  [CHAIN_IDs.SCROLL_SEPOLIA]: { name: "Scroll Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.scrollscan.com" },
-  [CHAIN_IDs.SEPOLIA]: { name: "Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia.etherscan.io" },
-  [CHAIN_IDs.ZK_SYNC_SEPOLIA]: { name: "zkSync Sepolia", nativeToken: "ETH", blockExplorer: "https://sepolia-era.zksync.network" }
+  [CHAIN_IDs.ARBITRUM_SEPOLIA]: {
+    name: "Arbitrum Sepolia",
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.arbiscan.io"
+  },
+  [CHAIN_IDs.BASE_SEPOLIA]: {
+    name: "Base Sepolia",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.basescan.org"
+  },
+  [CHAIN_IDs.BLAST_SEPOLIA]: {
+    name: "Blast Sepolia",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.blastscan.io"
+  },
+  [CHAIN_IDs.LISK_SEPOLIA]: {
+    name: "Lisk Sepolia",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia-blockscout.lisk.com"
+  },
+  [CHAIN_IDs.MODE_SEPOLIA]: {
+    name: "Mode Sepolia",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.explorer.mode.network"
+  },
+  [CHAIN_IDs.OPTIMISM_SEPOLIA]: {
+    name: "Optimism Sepolia",
+    family: OP_STACK,
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia-optimism.etherscan.io"
+  },
+  [CHAIN_IDs.POLYGON_AMOY]: {
+    name: "Polygon Amoy",
+    nativeToken: "MATIC",
+    blockExplorer: "https://amoy.polygonscan.com"
+  },
+  [CHAIN_IDs.SCROLL_SEPOLIA]: {
+    name: "Scroll Sepolia",
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.scrollscan.com"
+  },
+  [CHAIN_IDs.SEPOLIA]: {
+    name: "Sepolia",
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia.etherscan.io"
+  },
+  [CHAIN_IDs.ZK_SYNC_SEPOLIA]: {
+    name: "zkSync Sepolia",
+    nativeToken: "ETH",
+    blockExplorer: "https://sepolia-era.zksync.network"
+  }
 };
 
 export const PUBLIC_NETWORKS = {


### PR DESCRIPTION
Currently only identifying OP stack chains, but future candidates would be the corresponding variants from Arbitrum, Polygon, zkSync, ...