### PR TITLE
chore: Add Aleph Zero definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.16",
+  "version": "3.1.17",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -42,7 +42,7 @@ export const CHAIN_IDs = {
 
 export enum ChainFamily {
   OP_STACK,
-  ORBIT,
+  ORBIT, // Future: Might need to distinguish between ORBIT_L2 and ORBIT_L3...
 };
 
 interface PublicNetwork {

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -17,6 +17,7 @@ export const TESTNET_CHAIN_IDs = {
 } as const;
 
 export const MAINNET_CHAIN_IDs = {
+  ALEPH_ZERO: 41455,
   ARBITRUM: 42161,
   BASE: 8453,
   BLAST: 81457,
@@ -41,6 +42,7 @@ export const CHAIN_IDs = {
 
 export enum ChainFamily {
   OP_STACK,
+  ARBITRUM_ORBIT,
 };
 
 interface PublicNetwork {
@@ -50,8 +52,14 @@ interface PublicNetwork {
   family?: ChainFamily;
 }
 
-const { OP_STACK } = ChainFamily;
+const { ARBITRUM_ORBIT, OP_STACK } = ChainFamily;
 export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
+  [CHAIN_IDs.ALEPH_ZERO]: {
+    name: "Aleph Zero",
+    family: ARBITRUM_ORBIT,
+    nativeToken: "AZERO",
+    blockExplorer: "https://evm-explorer.alephzero.org",
+  },
   [CHAIN_IDs.ARBITRUM]: {
     name: "Arbitrum One",
     nativeToken: "ETH",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -42,7 +42,7 @@ export const CHAIN_IDs = {
 
 export enum ChainFamily {
   OP_STACK,
-  ARBITRUM_ORBIT,
+  ORBIT,
 };
 
 interface PublicNetwork {
@@ -52,11 +52,11 @@ interface PublicNetwork {
   family?: ChainFamily;
 }
 
-const { ARBITRUM_ORBIT, OP_STACK } = ChainFamily;
+const { ORBIT, OP_STACK } = ChainFamily;
 export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
   [CHAIN_IDs.ALEPH_ZERO]: {
     name: "Aleph Zero",
-    family: ARBITRUM_ORBIT,
+    family: ORBIT,
     nativeToken: "AZERO",
     blockExplorer: "https://evm-explorer.alephzero.org",
   },

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -27,6 +27,16 @@ export const TOKEN_SYMBOLS_MAP = {
     },
     coingeckoId: "arbitrum",
   },
+  AZERO: {
+    name: "Aleph Zero",
+    symbol: "AZERO",
+    decimals: 18,
+    addresses: {
+      [CHAIN_IDs.ALEPH_ZERO]: "0xb7Da55D7040ef9C887e20374D76A88F93A59119E",
+      [CHAIN_IDs.MAINNET]: "0xdD0ae774F7E300CdAA4EA371cD55169665Ee6AFe",
+    },
+    coingeckoId: "aleph-zero",
+  },
   BAL: {
     name: "Balancer",
     symbol: "BAL",
@@ -265,6 +275,16 @@ export const TOKEN_SYMBOLS_MAP = {
       [CHAIN_IDs.ZK_SYNC]: "0x493257fD37EDB34451f62EDf8D2a0C418852bA4C",
     },
     coingeckoId: "tether",
+  },
+  WAZERO: {
+    name: "Wrapped AZERO",
+    symbol: "WAZERO",
+    decimals: 18,
+    addresses: {
+      [CHAIN_IDs.ALEPH_ZERO]: "0xb7Da55D7040ef9C887e20374D76A88F93A59119E",
+      [CHAIN_IDs.MAINNET]: "0xdD0ae774F7E300CdAA4EA371cD55169665Ee6AFe",
+    },
+    coingeckoId: "aleph-zero",
   },
   WBTC: {
     name: "Wrapped Bitcoin",


### PR DESCRIPTION
I'm not 100% sure how much we're going to need the AZERO/WAZERO definitions, but have added them as a precaution. Non-ETH gas tokens definitely expose some quirks in the way we resolve tokens in the FE and the bots; that's tech debt that we'll need to reconcile before too long.