### PR TITLE
feat: use viem chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.18",
+  "version": "3.1.19",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",
@@ -58,5 +58,8 @@
       "require": "./dist/cjs/*.js",
       "import": "./dist/esm/*.js"
     }
+  },
+  "dependencies": {
+    "viem": "^2.21.37"
   }
 }

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,41 +1,133 @@
+import { Chain, defineChain } from "viem";
+import {
+  arbitrum,
+  arbitrumSepolia,
+  base,
+  baseSepolia,
+  blast,
+  blastSepolia,
+  boba,
+  linea,
+  lisk,
+  liskSepolia,
+  mainnet,
+  mode,
+  modeTestnet,
+  optimism,
+  optimismSepolia,
+  polygon,
+  polygonAmoy,
+  redstone,
+  scroll,
+  scrollSepolia,
+  sepolia,
+  worldchain,
+  zksync,
+  zksyncSepoliaTestnet,
+  zora,
+} from "viem/chains";
+
+type TestnetChainKey = keyof typeof TESTNET_SEPOLIA_CHAINS;
+type MainnetChainKey = keyof typeof MAINNET_CHAINS;
+
+// Custom chains
+const alephZero = defineChain({
+  id: 41_455,
+  name: "Aleph Zero",
+  nativeCurrency: {
+    name: "Aleph Zero",
+    symbol: "AZERO",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.alephzero.org"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "EVM Explorer",
+      url: "https://evm-explorer.alephzero.org",
+      apiUrl: "https://evm-explorer.alephzero.org/api",
+    },
+  },
+});
+const superseed = defineChain({
+  id: 5330,
+  name: "Superseed",
+  nativeCurrency: {
+    name: "Ether",
+    symbol: "ETH",
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: [""], // TODO
+    },
+  },
+  blockExplorers: {
+    default: {
+      // TODO
+      name: "",
+      url: "",
+      apiUrl: "",
+    },
+  },
+});
+
 // Chain names and IDs.
-export const TESTNET_SEPOLIA_CHAIN_IDs = {
-  ARBITRUM_SEPOLIA: 421614,
-  BASE_SEPOLIA: 84532,
-  BLAST_SEPOLIA: 168587773,
-  LISK_SEPOLIA: 4202,
-  MODE_SEPOLIA: 919,
-  OPTIMISM_SEPOLIA: 11155420,
-  POLYGON_AMOY: 80002,
-  SCROLL_SEPOLIA: 534351,
-  SEPOLIA: 11155111,
-  ZK_SYNC_SEPOLIA: 300,
+export const TESTNET_SEPOLIA_CHAINS = {
+  ARBITRUM_SEPOLIA: arbitrumSepolia,
+  BASE_SEPOLIA: baseSepolia,
+  BLAST_SEPOLIA: blastSepolia,
+  LISK_SEPOLIA: liskSepolia,
+  MODE_SEPOLIA: modeTestnet,
+  OPTIMISM_SEPOLIA: optimismSepolia,
+  POLYGON_AMOY: polygonAmoy,
+  SCROLL_SEPOLIA: scrollSepolia,
+  SEPOLIA: sepolia,
+  ZK_SYNC_SEPOLIA: zksyncSepoliaTestnet,
 };
+
+export const MAINNET_CHAINS = {
+  ALEPH_ZERO: alephZero,
+  ARBITRUM: arbitrum,
+  BASE: base,
+  BLAST: blast,
+  BOBA: boba,
+  LINEA: linea,
+  LISK: lisk,
+  MAINNET: mainnet,
+  MODE: mode,
+  OPTIMISM: optimism,
+  POLYGON: polygon,
+  REDSTONE: redstone,
+  SCROLL: scroll,
+  SUPERSEED: superseed,
+  WORLD_CHAIN: worldchain,
+  ZK_SYNC: zksync,
+  ZORA: zora,
+};
+
+export const TESTNET_SEPOLIA_CHAIN_IDs = Object.entries(TESTNET_SEPOLIA_CHAINS).reduce(
+  (acc, [key, chain]) => {
+    acc[key as TestnetChainKey] = chain.id;
+    return acc;
+  },
+  {} as Record<TestnetChainKey, number>,
+);
 
 export const TESTNET_CHAIN_IDs = {
   ...TESTNET_SEPOLIA_CHAIN_IDs,
 } as const;
 
-export const MAINNET_CHAIN_IDs = {
-  ALEPH_ZERO: 41455,
-  ARBITRUM: 42161,
-  BASE: 8453,
-  BLAST: 81457,
-  BOBA: 288,
-  LINEA: 59144,
-  LISK: 1135,
-  MAINNET: 1,
-  MODE: 34443,
-  OPTIMISM: 10,
-  POLYGON: 137,
-  REDSTONE: 690,
-  SCROLL: 534352,
-  SUPERSEED: 5330,
-  WORLD_CHAIN: 480,
-  ZK_SYNC: 324,
-  ZORA: 7777777
-};
-
+export const MAINNET_CHAIN_IDs = Object.entries(MAINNET_CHAINS).reduce(
+  (acc, [key, chain]) => {
+    acc[key as MainnetChainKey] = chain.id;
+    return acc;
+  },
+  {} as Record<MainnetChainKey, number>,
+);
 export const CHAIN_IDs = {
   ...MAINNET_CHAIN_IDs,
   ...TESTNET_CHAIN_IDs,
@@ -44,7 +136,26 @@ export const CHAIN_IDs = {
 export enum ChainFamily {
   OP_STACK,
   ORBIT, // Future: Might need to distinguish between ORBIT_L2 and ORBIT_L3...
-};
+}
+
+export const OP_STACK_CHAIN_IDs = [
+  CHAIN_IDs.BASE,
+  CHAIN_IDs.BASE_SEPOLIA,
+  CHAIN_IDs.BLAST,
+  CHAIN_IDs.BLAST_SEPOLIA,
+  CHAIN_IDs.LISK,
+  CHAIN_IDs.LISK_SEPOLIA,
+  CHAIN_IDs.MODE,
+  CHAIN_IDs.MODE_SEPOLIA,
+  CHAIN_IDs.OPTIMISM,
+  CHAIN_IDs.OPTIMISM_SEPOLIA,
+  CHAIN_IDs.REDSTONE,
+  CHAIN_IDs.SUPERSEED,
+  CHAIN_IDs.WORLD_CHAIN,
+  CHAIN_IDs.ZORA,
+];
+
+export const ORBIT_CHAIN_IDs = [CHAIN_IDs.ALEPH_ZERO];
 
 interface PublicNetwork {
   name: string;
@@ -54,163 +165,39 @@ interface PublicNetwork {
 }
 
 const { ORBIT, OP_STACK } = ChainFamily;
-export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
-  [CHAIN_IDs.ALEPH_ZERO]: {
-    name: "Aleph Zero",
-    family: ORBIT,
-    nativeToken: "AZERO",
-    blockExplorer: "https://evm-explorer.alephzero.org",
-  },
-  [CHAIN_IDs.ARBITRUM]: {
-    name: "Arbitrum One",
-    nativeToken: "ETH",
-    blockExplorer: "https://arbiscan.io"
-  },
-  [CHAIN_IDs.BASE]: {
-    name: "Base",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://basescan.org"
-  },
-  [CHAIN_IDs.BLAST]: {
-    name: "Blast",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://blastscan.io"
-  },
-  [CHAIN_IDs.BOBA]: {
-    name: "Boba",
-    nativeToken: "ETH",
-    blockExplorer: "https://blockexplorer.boba.network"
-  },
-  [CHAIN_IDs.LINEA]: {
-    name: "Linea",
-    nativeToken: "ETH",
-    blockExplorer: "https://lineascan.build"
-  },
-  [CHAIN_IDs.LISK]: {
-    name: "Lisk",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://blockscout.lisk.com"
-  },
-  [CHAIN_IDs.MAINNET]: {
-    name: "Mainnet",
-    nativeToken: "ETH",
-    blockExplorer: "https://etherscan.io"
-  },
-  [CHAIN_IDs.MODE]: {
-    name: "Mode",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://explorer.mode.network"
-  },
-  [CHAIN_IDs.OPTIMISM]: {
-    name: "Optimism",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://optimistic.etherscan.io"
-  },
-  [CHAIN_IDs.POLYGON]: {
-    name: "Polygon",
-    nativeToken: "MATIC",
-    blockExplorer: "https://polygonscan.com"
-  },
-  [CHAIN_IDs.REDSTONE]: {
-    name: "Redstone",
-    nativeToken: "ETH",
-    blockExplorer: "https://explorer.redstone.xyz",
-    family: OP_STACK,
-  },
-  [CHAIN_IDs.SCROLL]: {
-    name: "Scroll",
-    nativeToken: "ETH",
-    blockExplorer: "https://scrollscan.com"
-  },
-  [CHAIN_IDs.SUPERSEED]: {
-    name: "Superseed",
-    nativeToken: "ETH",
-    blockExplorer: "", // @todo: To be added later
-    family: OP_STACK
-  },
-  [CHAIN_IDs.WORLD_CHAIN]: {
-    name: "World Chain",
-    nativeToken: "ETH",
-    blockExplorer: "https://worldchain-mainnet-explorer.alchemy.com",
-    family: OP_STACK
-  },
-  [CHAIN_IDs.ZK_SYNC]: {
-    name: "zkSync",
-    nativeToken: "ETH",
-    blockExplorer: "https://era.zksync.network"
-  },
-  [CHAIN_IDs.ZORA]: {
-    name: "Zora",
-    nativeToken: "ETH",
-    blockExplorer: "https://zorascan.xyz",
-    family: OP_STACK
-  }
-};
 
-export const TEST_NETWORKS: { [chainId: number]: PublicNetwork } = {
-  [CHAIN_IDs.ARBITRUM_SEPOLIA]: {
-    name: "Arbitrum Sepolia",
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.arbiscan.io"
+export const PRODUCTION_NETWORKS = Object.values(MAINNET_CHAINS).reduce(
+  (acc, chain) => {
+    const publicNetwork = definePublicNetwork(chain);
+    acc[chain.id] = publicNetwork;
+    return acc;
   },
-  [CHAIN_IDs.BASE_SEPOLIA]: {
-    name: "Base Sepolia",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.basescan.org"
-  },
-  [CHAIN_IDs.BLAST_SEPOLIA]: {
-    name: "Blast Sepolia",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.blastscan.io"
-  },
-  [CHAIN_IDs.LISK_SEPOLIA]: {
-    name: "Lisk Sepolia",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia-blockscout.lisk.com"
-  },
-  [CHAIN_IDs.MODE_SEPOLIA]: {
-    name: "Mode Sepolia",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.explorer.mode.network"
-  },
-  [CHAIN_IDs.OPTIMISM_SEPOLIA]: {
-    name: "Optimism Sepolia",
-    family: OP_STACK,
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia-optimism.etherscan.io"
-  },
-  [CHAIN_IDs.POLYGON_AMOY]: {
-    name: "Polygon Amoy",
-    nativeToken: "MATIC",
-    blockExplorer: "https://amoy.polygonscan.com"
-  },
-  [CHAIN_IDs.SCROLL_SEPOLIA]: {
-    name: "Scroll Sepolia",
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.scrollscan.com"
-  },
-  [CHAIN_IDs.SEPOLIA]: {
-    name: "Sepolia",
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia.etherscan.io"
-  },
-  [CHAIN_IDs.ZK_SYNC_SEPOLIA]: {
-    name: "zkSync Sepolia",
-    nativeToken: "ETH",
-    blockExplorer: "https://sepolia-era.zksync.network"
-  }
-};
+  {} as Record<number, PublicNetwork>,
+);
 
+export const TEST_NETWORKS = Object.values(TESTNET_SEPOLIA_CHAINS).reduce(
+  (acc, chain) => {
+    const publicNetwork = definePublicNetwork(chain);
+    acc[chain.id] = publicNetwork;
+    return acc;
+  },
+  {} as Record<number, PublicNetwork>,
+);
 export const PUBLIC_NETWORKS = {
   ...PRODUCTION_NETWORKS,
   ...TEST_NETWORKS,
 };
+
+function definePublicNetwork(chain: Chain): PublicNetwork {
+  const family = OP_STACK_CHAIN_IDs.includes(chain.id)
+    ? OP_STACK
+    : ORBIT_CHAIN_IDs.includes(chain.id)
+    ? ORBIT
+    : undefined;
+  return {
+    name: chain.name,
+    nativeToken: chain.nativeCurrency.symbol,
+    blockExplorer: chain.blockExplorers?.default.url ?? "",
+    family,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "module": "CommonJS",
-    // Target ES5
-    "target": "ES5",
+    // Target ES6
+    "target": "ES2020",
     // Set the import helpers
     "importHelpers": true,
     // output .d.ts declaration files for consumers

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adraffy/ens-normalize@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
+  integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
+
 "@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -58,6 +63,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@noble/curves@1.6.0", "@noble/curves@^1.4.0", "@noble/curves@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
+  integrity sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==
+  dependencies:
+    "@noble/hashes" "1.5.0"
+
+"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
+  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -90,6 +107,28 @@
     open "^9.1.0"
     picocolors "^1.0.0"
     tslib "^2.6.0"
+
+"@scure/base@~1.1.7", "@scure/base@~1.1.8":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.5.0.tgz#dd4a2e1b8a9da60e012e776d954c4186db6328e6"
+  integrity sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==
+  dependencies:
+    "@noble/curves" "~1.6.0"
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.7"
+
+"@scure/bip39@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.4.0.tgz#664d4f851564e2e1d4bffa0339f9546ea55960a6"
+  integrity sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==
+  dependencies:
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.8"
 
 "@types/json-schema@^7.0.12":
   version "7.0.13"
@@ -190,6 +229,11 @@
   dependencies:
     "@typescript-eslint/types" "6.7.3"
     eslint-visitor-keys "^3.4.1"
+
+abitype@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.6.tgz#76410903e1d88e34f1362746e2d407513c38565b"
+  integrity sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -1241,6 +1285,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isows@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.6.tgz#0da29d706fa51551c663c627ace42769850f86e7"
+  integrity sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==
+
 js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
@@ -1871,6 +1920,29 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+viem@^2.21.37:
+  version "2.21.37"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.37.tgz#4d67bee8749321b0fd142c54df2021d5774403b1"
+  integrity sha512-JupwyttT4aJNnP9+kD7E8jorMS5VmgpC3hm3rl5zXsO8WNBTsP3JJqZUSg4AG6s2lTrmmpzS/qpmXMZu5gJw5Q==
+  dependencies:
+    "@adraffy/ens-normalize" "1.11.0"
+    "@noble/curves" "1.6.0"
+    "@noble/hashes" "1.5.0"
+    "@scure/bip32" "1.5.0"
+    "@scure/bip39" "1.4.0"
+    abitype "1.0.6"
+    isows "1.0.6"
+    webauthn-p256 "0.0.10"
+    ws "8.18.0"
+
+webauthn-p256@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.10.tgz#877e75abe8348d3e14485932968edf3325fd2fdd"
+  integrity sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==
+  dependencies:
+    "@noble/curves" "^1.4.0"
+    "@noble/hashes" "^1.4.0"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -1904,6 +1976,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
While working on including viem in the SDK and also in the context of the app-sdk, I noticed that it could be useful to have a set list of supported chains that can be used to configure viem clients.

This should not break any downstream deps. 