### PR TITLE
fix(zora): op stack family

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.24",
+  "version": "3.1.25",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -162,7 +162,7 @@ export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
   },
   [CHAIN_IDs.ZORA]: {
     name: "Zora",
-    family: NONE,
+    family: OP_STACK,
     nativeToken: "ETH",
     blockExplorer: "https://zorascan.xyz",
   }


### PR DESCRIPTION
I believe this was set to NONE in error. This is confirmed by Zora's official docs https://docs.zora.co/zora-network/intro