### PR TITLE
fix: use different GRASS sepolia address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.26",
+  "version": "3.1.27",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -382,7 +382,7 @@ export const TOKEN_SYMBOLS_MAP = {
     decimals: 18,
     addresses: {
       [CHAIN_IDs.LENS_SEPOLIA]: "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8",
-      [CHAIN_IDs.SEPOLIA]: "0x8D725d9dBBb5E0667efeDC833D6A9e8C6cA02C68"
+      [CHAIN_IDs.SEPOLIA]: "0x2Be68B15c693D3b5747F9F0D49D30A2E81BAA2Df"
     },
     coingeckoId: "grass" // TODO: verify when listed
   },
@@ -392,7 +392,7 @@ export const TOKEN_SYMBOLS_MAP = {
     decimals: 18,
     addresses: {
       [CHAIN_IDs.LENS_SEPOLIA]: "0xeee5a340Cdc9c179Db25dea45AcfD5FE8d4d3eB8",
-      [CHAIN_IDs.SEPOLIA]: "0x8D725d9dBBb5E0667efeDC833D6A9e8C6cA02C68"
+      [CHAIN_IDs.SEPOLIA]: "0x2Be68B15c693D3b5747F9F0D49D30A2E81BAA2Df"
     },
     coingeckoId: "wgrass" // TODO: verify when listed
   },


### PR DESCRIPTION
I believe the grass address on sepolia we need to use is 0x2Be68B15c693D3b5747F9F0D49D30A2E81BAA2Df. This is because this is the token being transferred when bridging. Examples:
(As a custom gas token, bridging ETH): https://sepolia.etherscan.io/tx/0xff8412513a97fefa370992142e0e7a5c065ceb9b0aaa37f88eb58ffabf6c7788
(As the native token): https://sepolia.etherscan.io/tx/0x9a6ae414187e901e6994a69f544abbbef42953cec01b440163dcf875df543e75