### PR TITLE
chore: Bump node version in publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: "20.x"
           always-auth: true
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
This package builds OK locally, but fails when trying to publish a release.