### PR TITLE
improve: add token remappings for tatara constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.46",
+  "version": "3.1.47",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -510,4 +510,7 @@ export const TOKEN_EQUIVALENCE_REMAPPING: { [symbol: string]: string } = {
   [TOKEN_SYMBOLS_MAP["USDzC"].symbol]: TOKEN_SYMBOLS_MAP["USDC"].symbol,
   [TOKEN_SYMBOLS_MAP["USDB"].symbol]: TOKEN_SYMBOLS_MAP["DAI"].symbol,
   "LGHO": TOKEN_SYMBOLS_MAP["WGHO"].symbol, // LGHO is the symbol for WGHO on L1.
+  // Testnet remappings.
+  [TOKEN_SYMBOLS_MAP["TATARA-WETH"].symbol]: TOKEN_SYMBOLS_MAP["WETH"].symbol,
+  [TOKEN_SYMBOLS_MAP["TATARA-USDC"].symbol]: TOKEN_SYMBOLS_MAP["USDC"].symbol,
 };


### PR DESCRIPTION
This is needed for the relayer's ProfitClient here: https://github.com/across-protocol/relayer/blob/12e42bb2fb73721810902fd98dfc1a8499d289aa/src/clients/ProfitClient.ts#L182