### PR TITLE
feat: add HyperCore definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.76",
+  "version": "3.1.77",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -32,6 +32,7 @@ export const MAINNET_CHAIN_IDs = {
   BSC: 56,
   BOBA: 288,
   HYPEREVM: 999,
+  HYPERCORE: 1337, // Arbitrary chain id for HyperCore
   INK: 57073,
   LENS: 232,
   LINEA: 59144,
@@ -185,6 +186,16 @@ export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
     cctpDomain: 19,
     oftEid: PRODUCTION_OFT_EIDs.HYPEREVM,
     hypDomainId: CHAIN_IDs.HYPEREVM,
+  },
+  [CHAIN_IDs.HYPERCORE]: {
+    name: "HyperCore",
+    family: NONE,
+    nativeToken: "HYPE",
+    publicRPC: "https://api.hyperliquid.xyz",
+    blockExplorer: "https://app.hyperliquid.xyz/explorer",
+    cctpDomain: CCTP_NO_DOMAIN,
+    oftEid: OFT_NO_EID,
+    hypDomainId: HYPERLANE_NO_DOMAIN_ID,
   },
   [CHAIN_IDs.UNICHAIN]: {
     name: "Unichain",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -455,6 +455,18 @@ export const TOKEN_SYMBOLS_MAP = {
     l1TokenDecimals: 6,
     coingeckoId: "tether",
   },
+  "USDT-SPOT": {
+    name: "Tether USD",
+    symbol: "USDT-SPOT",
+    decimals: 8,
+    addresses: {
+      [CHAIN_IDs.HYPERCORE]: "0x200000000000000000000000000000000000010C",
+      [CHAIN_IDs.HYPEREVM]: "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+      [CHAIN_IDs.MAINNET]: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    },
+    l1TokenDecimals: 6,
+    coingeckoId: "tether",
+  },
   VLR: {
     name: "Velora",
     symbol: "VLR",


### PR DESCRIPTION
These will only be used by the APIs and FE. Note that the chain ID is an arbitrary one as HyperCore is non-EVM. I am using the same as Relay and LiFi but we could also use a different one.