### PR TITLE
fix: revert hypercore chain id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.79",
+  "version": "3.1.80",
   "description": "Export commonly re-used values for Across repositories",
   "repository": "https://github.com/across-protocol/constants.git",
   "author": "hello@umaproject.org",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -33,7 +33,7 @@ export const MAINNET_CHAIN_IDs = {
   BSC: 56,
   BOBA: 288,
   HYPEREVM: 999,
-  HYPERCORE: 239048, // Arbitrary chain id for HyperCore
+  HYPERCORE: 1337, // Arbitrary chain ID for HyperCore but consistent with other APIs
   INK: 57073,
   LENS: 232,
   LINEA: 59144,


### PR DESCRIPTION
@fusmanii @bmzig I saw we changed the chain ID for HyperCore to something different here https://github.com/across-protocol/constants/pull/158. Is it possible to change the used chain ID in the relayer tests directly? The reason is that we want to keep the required chain ID for HyperCore consistent with other protocols.