### PR TITLE
feat: Add LSK on Base

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -231,6 +231,7 @@ export const TOKEN_SYMBOLS_MAP = {
     symbol: "LSK",
     decimals: 18,
     addresses: {
+      [CHAIN_IDs.BASE]: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
       [CHAIN_IDs.LISK]: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
       [CHAIN_IDs.MAINNET]: "0x6033F7f88332B8db6ad452B7C6D5bB643990aE3f",
     },


### PR DESCRIPTION
## Summary
Adds the Base chain entry to the `LSK` token in `TOKEN_SYMBOLS_MAP`.

Lisk's L2 token is deployed on Base at the same address as on the Lisk chain — `0xac485391EB2d7D88253a7F1eF18C37f4242D1A24` — via the Superchain canonical token deployment.

```diff
LSK: {
  name: "Lisk",
  symbol: "LSK",
  decimals: 18,
  addresses: {
+   [CHAIN_IDs.BASE]: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
    [CHAIN_IDs.LISK]: "0xac485391EB2d7D88253a7F1eF18C37f4242D1A24",
    [CHAIN_IDs.MAINNET]: "0x6033F7f88332B8db6ad452B7C6D5bB643990aE3f",
  },
  coingeckoId: "lisk",
},
```

### Verification
- BaseScan: https://basescan.org/token/0xac485391eb2d7d88253a7f1ef18c37f4242d1a24 — verified contract, name `Lisk`, symbol `LSK`, 18 decimals.
- CoinGecko `lisk` token lists `base` under `platforms` with this same address.

### Why
Required by Across frontend [FE-485](https://linear.app/uma/issue/FE-485/enabling-lsk-base-on-our-fe) — enabling LSK as a bridgeable token between Base and Mainnet/Lisk. The dapp's route generator reads `TOKEN_SYMBOLS_MAP[symbol].addresses[chainId]`; without an entry here, no LSK↔Base routes are produced.

Companion PR: [across-protocol/dapp#312](https://github.com/across-protocol/dapp/pull/312).

## Test plan
- [ ] No type or build regressions
- [ ] Consumers can resolve `TOKEN_SYMBOLS_MAP.LSK.addresses[CHAIN_IDs.BASE]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)