### PR TITLE
chore: bump version to 3.1.121

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.120",
+  "version": "3.1.121",
   "description": "Export commonly re-used values for Across repositories",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bumps `@across-protocol/constants` from 3.1.120 to 3.1.121.

Unreleased change since v3.1.120:
- #216 feat: Add USDT on Soneium

Once merged, creating a GitHub release tagged `v3.1.121` will trigger the npm publish workflow.

Requested by Alex M in Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)