### PR TITLE
chore: remove testnet XYZ token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.123",
+  "version": "3.1.124",
   "description": "Export commonly re-used values for Across repositories",
   "repository": {
     "type": "git",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -793,17 +793,6 @@ export const TOKEN_SYMBOLS_MAP = {
     },
     coingeckoId: "plasma",
   },
-  XYZ: {
-    name: "XYZ Token",
-    symbol: "XYZ",
-    decimals: 18,
-    addresses: {
-      [CHAIN_IDs.BASE_SEPOLIA]: "0x180D555759e4d1d5Cf70C3BaBbAE4B8F410BDAD9",
-      [CHAIN_IDs.OPTIMISM_SEPOLIA]: "0x180D555759e4d1d5Cf70C3BaBbAE4B8F410BDAD9",
-      [CHAIN_IDs.SEPOLIA]: "0x180D555759e4d1d5Cf70C3BaBbAE4B8F410BDAD9",
-    },
-    coingeckoId: "xyz", // This is a testnet token only.
-  },
 };
 
 // Hard-coded mapping of token symbols that should be treated as having equivalent


### PR DESCRIPTION
## Summary

Removes the XYZ test token definition from `TOKEN_SYMBOLS_MAP` and bumps to 3.1.124. XYZ (`0x180D555759e4d1d5Cf70C3BaBbAE4B8F410BDAD9` on Sepolia, Base Sepolia and Optimism Sepolia) was added in #109 for Paraswap integration testing and is no longer needed. Requested by @pxrl in Slack.

⚠️ Merge order: land the consumer cleanups first — [quote-api#2916](https://github.com/across-protocol/quote-api/pull/2916) and [dapp#462](https://github.com/across-protocol/dapp/pull/462). quote-api in particular references `XYZ` in its capital-cost config (`populateDefaultRelayerFeeCapitalCostConfig` throws on symbols missing from `TOKEN_SYMBOLS_MAP`), so bumping constants past this change before #2916 would break it at module load. Existing consumers are unaffected until they bump.

## Test plan
- [x] `yarn build` (cjs + esm + types) clean
- [x] `yarn eslint` clean; the `yarn lint` prettier step flags `README.md` on master already (pre-existing, untouched here)
- [x] No other XYZ references in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)