### PR TITLE
feat: Add USDe token and Robinhood OFT EID

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/constants",
-  "version": "3.1.123",
+  "version": "3.1.124",
   "description": "Export commonly re-used values for Across repositories",
   "repository": {
     "type": "git",

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -93,6 +93,7 @@ export const PRODUCTION_OFT_EIDs = {
   OPTIMISM: 30111,
   PLASMA: 30383,
   POLYGON: 30109,
+  ROBINHOOD: 30416,
   SONEIUM: 30340,
   TEMPO: 30410,
   TRON: 30420,
@@ -395,7 +396,7 @@ export const PRODUCTION_NETWORKS: { [chainId: number]: PublicNetwork } = {
     publicRPC: "https://rpc.mainnet.chain.robinhood.com",
     blockExplorer: "https://robinhoodchain.blockscout.com",
     cctpDomain: CCTP_NO_DOMAIN,
-    oftEid: OFT_NO_EID,
+    oftEid: PRODUCTION_OFT_EIDs.ROBINHOOD,
     hypDomainId: HYPERLANE_NO_DOMAIN_ID,
   },
   [CHAIN_IDs.SCROLL]: {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -461,6 +461,16 @@ export const TOKEN_SYMBOLS_MAP = {
     },
     coingeckoId: "usd-coin",
   },
+  USDe: {
+    name: "USDe",
+    symbol: "USDe",
+    decimals: 18,
+    addresses: {
+      [CHAIN_IDs.MAINNET]: "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3",
+      [CHAIN_IDs.ROBINHOOD]: "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
+    },
+    coingeckoId: "ethena-usde",
+  },
   USDG: {
     name: "Global Dollar",
     symbol: "USDG",


### PR DESCRIPTION
## What

- `PRODUCTION_OFT_EIDs.ROBINHOOD = 30416` and wire `PUBLIC_NETWORKS[4663].oftEid` (was `OFT_NO_EID`).
- Add `USDe` to `TOKEN_SYMBOLS_MAP` (Ethena, 18 decimals, `ethena-usde`):
  - Mainnet ERC-20: `0x4c9EDD5852cd905f086C759E8383e09bff1E68B3`
  - Robinhood OFT: `0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34`
- Version bump 3.1.123 → 3.1.124.

## Why

Unblocks routing USDe via the OFT bridge provider into Robinhood Chain (4663) in the Swap API. Companion quote-api PR adds the `OFT_MESSENGERS`/`OFT_SHARED_DECIMALS` entries and routing override; it depends on this release. The `oftEid` also flows into the V5 integrator-api chain manifest (which composes chain identity + cctpDomain + oftEid from this package), so V5 reuses this half when its OFT lanes go live.

## Verification (on-chain, 2026-08-03)

- EID 30416 read from the LayerZero EndpointV2 on 4663 (`0x6F475642a6e85809B1c36Fa62763669b1b48DD5B`, `eid()`).
- USDe on 4663 is a LayerZero V2 OFT: `decimals()=18`, `sharedDecimals()=6`, `oftVersion()` interface present.
- Ethereum adapter (`0x5d3a…ef34`, lockbox over the ERC-20) has `peers(30416)` set to the 4663 OFT, and the 4663 OFT has `peers(30101)` set back — both directions quote cleanly via `quoteSend`/`quoteOFT` (zero OFT fee, no rate limit).
- Addresses checksummed via `cast to-check-sum-address`.

Note: `yarn lint` fails on master due to a pre-existing `prettier --list-different` hit on `README.md`; the files touched here are prettier-clean and `yarn build` passes.

Slack context: thread `C0B8BQX8DJ8/1785416924.363739`

🤖 Generated with [Claude Code](https://claude.com/claude-code)